### PR TITLE
Add make script for ref counter example

### DIFF
--- a/cpp/memory_ordering/ref_counter_example/example.cpp
+++ b/cpp/memory_ordering/ref_counter_example/example.cpp
@@ -1,0 +1,57 @@
+#include "intrusive_ref_count.hpp"
+
+#include <cassert>
+#include <chrono>
+#include <iostream>
+#include <thread>
+#include <vector>
+
+struct Foo : RefCounted {
+  int value;
+
+  explicit Foo(int v) : value(v) {
+    // Publish initialization before anyone else sees the pointer.
+    // Subsequent increments are relaxed; the last decrement will synchronize
+    // with this thread before the destructor runs.
+  }
+
+  ~Foo() override {
+    // The acquire fence in the final release_ref() ensures all prior writes
+    // to this object (e.g., 'value' updates) are visible here.
+    std::cout << "Foo destroyed, value=" << value << "\n";
+  }
+};
+
+int main() {
+  auto sp = make_intrusive<Foo>(42);
+
+  // Demonstrate concurrent copies and releases.
+  constexpr int N = 8;
+  constexpr int CopiesPerThread = 10000;
+
+  std::vector<std::thread> threads;
+  threads.reserve(N);
+
+  for (int i = 0; i < N; ++i) {
+    threads.emplace_back([sp] () mutable {
+      // Make and drop many copies; increments are relaxed, decrements are release.
+      for (int j = 0; j < CopiesPerThread; ++j) {
+        IntrusivePtr<Foo> local = sp; // add_ref (relaxed)
+        assert(local->value == 42);
+        // local goes out of scope here; release_ref (release, maybe final -> acquire fence)
+      }
+    });
+  }
+
+  for (auto& t : threads) t.join();
+
+  // Change a field; other threads have finished, but this shows ordinary writes.
+  sp->value = 7;
+
+  // Drop the last strong reference; if this is the last, destructor runs after acquire fence.
+  sp.reset();
+
+  // Give stdout time to flush in some environments.
+  std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  return 0;
+}

--- a/cpp/memory_ordering/ref_counter_example/intrusive_ref_count.hpp
+++ b/cpp/memory_ordering/ref_counter_example/intrusive_ref_count.hpp
@@ -1,0 +1,137 @@
+#pragma once
+
+#include <atomic>
+#include <cstddef>
+#include <utility>
+#include <type_traits>
+#include <new>
+
+// Minimal intrusive reference counting primitives demonstrating correct memory ordering.
+// - Increments only need atomicity (relaxed).
+// - Decrements must publish-with-release and pair with an acquire before destruction,
+//   so that the destructor observes all prior writes by the last owner.
+//
+// This mirrors the core idea used by std::shared_ptr's control block counters,
+// though std::shared_ptr also maintains separate strong/weak counts and other logic.
+
+struct RefCounted {
+  // Start at 1 when created/returned from a factory like make_intrusive.
+  mutable std::atomic<std::size_t> refs{1};
+
+protected:
+  // Ensure polymorphic cleanup works.
+  virtual ~RefCounted() = default;
+
+public:
+  void add_ref() const noexcept {
+    // Only atomicity is required for increments; no ordering necessary.
+    refs.fetch_add(1, std::memory_order_relaxed);
+  }
+
+  // Returns true if this call deleted the object (i.e., ref count reached zero).
+  bool release_ref() const noexcept {
+    // Use release on the decrement to publish prior writes in the releasing thread(s).
+    // If this was the last reference, perform an acquire fence before destruction
+    // to synchronize-with the release and make prior writes visible to the destructor.
+    if (refs.fetch_sub(1, std::memory_order_release) == 1) {
+      std::atomic_thread_fence(std::memory_order_acquire);
+      delete this;
+      return true;
+    }
+    return false;
+  }
+
+  std::size_t use_count_relaxed() const noexcept {
+    // For diagnostics only; not a reliable liveness check under concurrency.
+    return refs.load(std::memory_order_relaxed);
+  }
+};
+
+// A simple intrusive smart pointer that expects T to derive from RefCounted.
+// This is intentionally minimal: no weak pointers, no aliasing constructors, etc.
+template <class T>
+class IntrusivePtr {
+  static_assert(std::is_base_of<RefCounted, T>::value,
+                "IntrusivePtr<T>: T must derive from RefCounted");
+
+public:
+  using element_type = T;
+
+  constexpr IntrusivePtr() noexcept = default;
+
+  // Takes ownership of p (assumes p has refcount >= 1 for this owner).
+  explicit IntrusivePtr(T* p) noexcept : ptr_(p) {}
+
+  // Copy: add one reference (relaxed).
+  IntrusivePtr(const IntrusivePtr& other) noexcept : ptr_(other.ptr_) {
+    if (ptr_) ptr_->add_ref();
+  }
+
+  // Move: steal the pointer.
+  IntrusivePtr(IntrusivePtr&& other) noexcept : ptr_(other.ptr_) {
+    other.ptr_ = nullptr;
+  }
+
+  // Construct from a raw pointer without incrementing if 'add_ref' is false.
+  // Useful for factory functions that return a freshly-created object with refs == 1.
+  struct adopt_ref_t { explicit adopt_ref_t() = default; };
+  static constexpr adopt_ref_t adopt_ref{};
+
+  IntrusivePtr(T* p, adopt_ref_t) noexcept : ptr_(p) {}
+
+  // Copy assign.
+  IntrusivePtr& operator=(const IntrusivePtr& other) noexcept {
+    if (this == &other) return *this;
+    // Add ref first in case other.ptr_ == ptr_ (self-assignment protection)
+    T* p = other.ptr_;
+    if (p) p->add_ref();
+    reset(ptr_);
+    ptr_ = p;
+    return *this;
+  }
+
+  // Move assign.
+  IntrusivePtr& operator=(IntrusivePtr&& other) noexcept {
+    if (this == &other) return *this;
+    reset(ptr_);
+    ptr_ = other.ptr_;
+    other.ptr_ = nullptr;
+    return *this;
+  }
+
+  ~IntrusivePtr() {
+    reset(ptr_);
+  }
+
+  void reset() noexcept {
+    reset(ptr_);
+    ptr_ = nullptr;
+  }
+
+  void reset(T* p) noexcept {
+    if (p == ptr_) return;
+    T* old = ptr_;
+    ptr_ = p;
+    if (old) old->release_ref(); // may delete 'old'
+  }
+
+  T* get() const noexcept { return ptr_; }
+  T& operator*() const noexcept { return *ptr_; }
+  T* operator->() const noexcept { return ptr_; }
+  explicit operator bool() const noexcept { return ptr_ != nullptr; }
+
+  void swap(IntrusivePtr& other) noexcept { std::swap(ptr_, other.ptr_); }
+
+private:
+  T* ptr_ = nullptr;
+};
+
+// Convenience factory that constructs T and returns IntrusivePtr<T> adopting the initial ref.
+template <class T, class... Args>
+IntrusivePtr<T> make_intrusive(Args&&... args) {
+  static_assert(std::is_base_of<RefCounted, T>::value,
+                "make_intrusive<T>: T must derive from RefCounted");
+  T* p = new T(std::forward<Args>(args)...);
+  // T's RefCounted base starts with refs == 1, so adopt it.
+  return IntrusivePtr<T>(p, typename IntrusivePtr<T>::adopt_ref_t{});
+}

--- a/cpp/memory_ordering/ref_counter_example/make.sh
+++ b/cpp/memory_ordering/ref_counter_example/make.sh
@@ -1,0 +1,1 @@
+g++ -std=c++14 -O2 -pthread example.cpp


### PR DESCRIPTION
This pull request introduces a new example demonstrating correct memory ordering for intrusive reference counting in C++. It adds a minimal, thread-safe intrusive smart pointer implementation and a usage example with multithreaded reference counting. The main focus is on ensuring proper atomic operations and memory fences for safe object lifetime management in concurrent scenarios.

Implementation of thread-safe intrusive reference counting:

* Added `intrusive_ref_count.hpp` implementing a `RefCounted` base class with atomic reference counting, ensuring increments are relaxed and decrements use release/acquire semantics for safe destruction in multithreaded contexts. Also provides a minimal `IntrusivePtr<T>` smart pointer and a `make_intrusive` factory function.

Example usage and demonstration:

* Added `example.cpp` showing how to use `IntrusivePtr` and `RefCounted` in a multithreaded environment, including concurrent reference manipulations and correct destruction ordering.

Build instructions:

* Added `make.sh` script to compile the example with appropriate flags for C++14 and threading support.This pull request adds a build script for the reference counter example, making it easier to compile the C++ code.

Build tooling:

* Added a `make.sh` script that compiles `example.cpp` with C++14, optimization, and pthread support.